### PR TITLE
Create directories for hdfs

### DIFF
--- a/2.6.0/Dockerfile
+++ b/2.6.0/Dockerfile
@@ -40,6 +40,7 @@ COPY conf  $HADOOP_HOME/etc/hadoop/
 RUN mkdir /data && \
     hdfs namenode -format
 VOLUME /data
+RUN mkdir  -p /data/dfs/data /data/dfs/name /data/dfs/namesecondary
 
 
 # Helper script for starting YARN

--- a/2.6.0/Dockerfile
+++ b/2.6.0/Dockerfile
@@ -37,10 +37,9 @@ RUN apt-get update && \
 COPY conf  $HADOOP_HOME/etc/hadoop/
 
 # Formatting HDFS
-RUN mkdir /data && \
+RUN mkdir -p /data/dfs/data /data/dfs/name /data/dfs/namesecondary && \
     hdfs namenode -format
 VOLUME /data
-RUN mkdir  -p /data/dfs/data /data/dfs/name /data/dfs/namesecondary
 
 
 # Helper script for starting YARN


### PR DESCRIPTION
Directories specified in `hdfs-site.xml` do not exist and do not appear to be created automatically.

This PR add the creation of those directories to the Dockerfile and closes #30. 
